### PR TITLE
bench: fix conflicts with symbol `random` on osx

### DIFF
--- a/bench/bench_dtoa.cc
+++ b/bench/bench_dtoa.cc
@@ -174,7 +174,7 @@ public:
     uint32_t operator()() { return Gen(); }
 };
 
-static JenkinsRandom random;
+static JenkinsRandom _random;
 
 //==================================================================================================
 //
@@ -259,7 +259,7 @@ static inline void Register_RandomBits_double()
     std::vector<double> numbers(NumFloats);
 
     std::uniform_int_distribution<uint64_t> gen(1, 0x7FF0000000000000ull - 1);
-    std::generate(numbers.begin(), numbers.end(), [&] { return ReinterpretBits<double>(gen(random)); });
+    std::generate(numbers.begin(), numbers.end(), [&] { return ReinterpretBits<double>(gen(_random)); });
 
     RegisterBenchmarks("Random-bits", numbers);
 }
@@ -269,7 +269,7 @@ static inline void Register_RandomBits_single()
     std::vector<float> numbers(NumFloats);
 
     std::uniform_int_distribution<uint32_t> gen(1, 0x7F800000u - 1);
-    std::generate(numbers.begin(), numbers.end(), [&] { return ReinterpretBits<float>(gen(random)); });
+    std::generate(numbers.begin(), numbers.end(), [&] { return ReinterpretBits<float>(gen(_random)); });
 
     RegisterBenchmarks("Random-bits", numbers);
 }
@@ -283,7 +283,7 @@ static inline void Register_Uniform(Float low, Float high)
     std::vector<Float> numbers(NumFloats);
 
     std::uniform_real_distribution<Float> gen(low, high);
-    std::generate(numbers.begin(), numbers.end(), [&] { return gen(random); });
+    std::generate(numbers.begin(), numbers.end(), [&] { return gen(_random); });
 
     RegisterBenchmarks(StrPrintf("Uniform %.1g/%.1g", low, high), numbers);
 }
@@ -325,7 +325,7 @@ static inline void Register_Digits_double(const char* name, int digits, int e10)
     std::uniform_int_distribution<int64_t> gen(kPow10_i64[digits - 1], kPow10_i64[digits] - 1);
 
     std::generate(numbers.begin(), numbers.end(), [&] {
-        int64_t n = gen(random);
+        int64_t n = gen(_random);
         if (n % 10 == 0)
             n += 1;
         std::string s;
@@ -369,7 +369,7 @@ static inline void Register_Digits_single(const char* name, int digits, int e10)
     std::uniform_int_distribution<int32_t> gen(kPow10_i32[digits - 1], kPow10_i32[digits] - 1);
 
     std::generate(numbers.begin(), numbers.end(), [&] {
-        int32_t n = gen(random);
+        int32_t n = gen(_random);
         if (n % 10 == 0)
             n += 1;
         std::string s;
@@ -401,7 +401,7 @@ static inline std::vector<double> GenRandomDigitData_double(int num_digits, int 
 
     for (int i = 0; i < count; ++i)
     {
-        const double d = gen(random);
+        const double d = gen(_random);
         const double rounded = ryu::Round10(d, -num_digits);
         result[i] = rounded;
     }
@@ -427,7 +427,7 @@ static inline std::vector<float> GenRandomDigitData_float(int digits, int count)
 
     for (int i = 0; i < count; ++i)
     {
-        const float d = gen(random);
+        const float d = gen(_random);
         const float rounded = ryu::Round10(d, -digits);
         result[i] = rounded;
     }

--- a/bench/bench_strtod.cc
+++ b/bench/bench_strtod.cc
@@ -141,7 +141,7 @@ public:
     uint32_t operator()() { return Gen(); }
 };
 
-static JenkinsRandom random;
+static JenkinsRandom _random;
 
 template <typename ...Args>
 static inline char const* StrPrintf(char const* format, Args&&... args)
@@ -164,10 +164,10 @@ static inline void RegisterUniform_double(char const* name, double min, double m
     std::generate(numbers.begin(), numbers.end(), [&] {
         char buf[128];
 
-        char* const end = ryu::Dtoa(buf, gen(random));
-        //char* const end = buf + std::snprintf(buf, 128, "%.17g", gen(random));
-        //char* const end = buf + std::snprintf(buf, 128, "%.19g", gen(random));
-        //char* const end = buf + std::snprintf(buf, 128, "%.20g", gen(random));
+        char* const end = ryu::Dtoa(buf, gen(_random));
+        //char* const end = buf + std::snprintf(buf, 128, "%.17g", gen(_random));
+        //char* const end = buf + std::snprintf(buf, 128, "%.19g", gen(_random));
+        //char* const end = buf + std::snprintf(buf, 128, "%.20g", gen(_random));
 
         return std::string(buf, end);
     });


### PR DESCRIPTION
Fixes #8

```
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: x86_64-apple-darwin19.6.0
```

```
Drachennest/bench/bench_strtod.cc:144:22: error: redefinition of
      'random' as different kind of symbol
static JenkinsRandom random;
                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/usr/include/stdlib.h:228:7: note:
      previous definition is here
long     random(void) __swift_unavailable("Use arc4random instead.");
         ^
```